### PR TITLE
Fix the syntax for the config settings

### DIFF
--- a/_extensions/audio-slideshow/_extension.yml
+++ b/_extensions/audio-slideshow/_extension.yml
@@ -15,16 +15,17 @@ contributes:
       script:
         - plugin.js
       config:
-        - prefix: getPath() + "/playback/"
-        - suffix: ".webm"
-        - textToSpeechURL: null
-        - defaultNotes: false
-        - defaultText: false
-        - advance: 0
-        - autoplay: false
-        - defaultDuration: 5
-        - defaultAudios: true
-        - defaultPlaybackRate: 1.0
-        - playerOpacity: 0.05
-        - playerStyle: "position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;"
-        - startAtFragment: false
+        audio:
+          prefix: "./audio/"
+          suffix: ".webm"
+          textToSpeechURL: null
+          defaultNotes: false
+          defaultText: false
+          advance: 0
+          autoplay: false
+          defaultDuration: 5
+          defaultAudios: true
+          defaultPlaybackRate: 1.0
+          playerOpacity: 0.05
+          playerStyle: "position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;"
+          startAtFragment: false

--- a/_extensions/audio-slideshow/_extension.yml
+++ b/_extensions/audio-slideshow/_extension.yml
@@ -27,5 +27,6 @@ contributes:
           defaultAudios: true
           defaultPlaybackRate: 1.0
           playerOpacity: 0.05
-          playerStyle: "position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;"
+          # playerStyle: "position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;"
+          playerStyle: "position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px"
           startAtFragment: false

--- a/_extensions/audio-slideshow/recorder.js
+++ b/_extensions/audio-slideshow/recorder.js
@@ -298,8 +298,8 @@ console.warn(blob.type);
 
 
 const initAudioRecorder = function(Reveal){
-  Reveal.addKeyBinding( { keyCode: 67, key: 'C', description: 'Toggle recording' }, function() { Recorder.toggleRecording(); } );
-  Reveal.addKeyBinding( { keyCode: 90, key: 'Z', description: 'Download recordings' }, function() { Recorder.downloadZip(); } );
+  Reveal.addKeyBinding( { keyCode: 78, key: 'N', description: 'Toggle narrative recording' }, function() { Recorder.toggleRecording(); } );
+  Reveal.addKeyBinding( { keyCode: 90, key: 'Z', description: 'Download narrative recordings' }, function() { Recorder.downloadZip(); } );
   Reveal.addKeyBinding( { keyCode: 84, key: 'T', description: 'Fetch text-to-speech audio files' }, function() { Recorder.fetchTTS(); } );
 
 	Reveal.addEventListener( 'fragmentshown', function( event ) {


### PR DESCRIPTION
This fixes the syntax for the config settings, so the correct RevealJS configuration/init sequence is created.

Fixes https://github.com/kapsner/audio-slideshow/issues/2